### PR TITLE
Fix cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,11 @@ project(cs_x86)
 # Suppress extra stuff from generated solution
 set(CMAKE_SUPPRESS_REGENERATION true)
 
+# Output all binary files into one folder
+if(NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${cs_x86_BINARY_DIR}/bin")
+endif()
+
 # set capstone options
 set(CAPSTONE_BUILD_STATIC OFF CACHE BOOL "...")
 set(CAPSTONE_BUILD_TESTS OFF CACHE BOOL "...")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required (VERSION 3.8)
+project(cs_x86)
 
 # Suppress extra stuff from generated solution
 set(CMAKE_SUPPRESS_REGENERATION true)
@@ -6,8 +7,8 @@ set(CMAKE_SUPPRESS_REGENERATION true)
 # set capstone options
 set(CAPSTONE_BUILD_STATIC OFF CACHE BOOL "...")
 set(CAPSTONE_BUILD_TESTS OFF CACHE BOOL "...")
-add_subdirectory("${PROJECT_SOURCE_DIR}/third_party/capstone")
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/third_party/capstone")
 
-add_subdirectory("${PROJECT_SOURCE_DIR}/cs_x86")
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/cs_x86")
 
-add_subdirectory("${PROJECT_SOURCE_DIR}/Tests.cs_x86")
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Tests.cs_x86")

--- a/Tests.cs_x86/CMakeLists.txt
+++ b/Tests.cs_x86/CMakeLists.txt
@@ -13,7 +13,7 @@ file (GLOB_RECURSE SOURCES
 
 csharp_set_windows_forms_properties("Properties/AssemblyInfo.cs")
 
-source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES})
+source_group(TREE ${CMAKE_CURRENT_LIST_DIR} FILES ${SOURCES})
 
 add_executable(Tests_cs_x86 ${SOURCES})
 set_target_properties(Tests_cs_x86 PROPERTIES 

--- a/Tests.cs_x86/CMakeLists.txt
+++ b/Tests.cs_x86/CMakeLists.txt
@@ -4,6 +4,11 @@ project(Tests_cs_x86 LANGUAGES CSharp)
 # Suppress extra stuff from generated solution
 set(CMAKE_SUPPRESS_REGENERATION true)
 
+# Output all binary files into one folder
+if(NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${Tests_cs_x86_BINARY_DIR}/bin")
+endif()
+
 include(CSharpUtilities)
 
 file (GLOB_RECURSE SOURCES
@@ -24,8 +29,3 @@ set_target_properties(Tests_cs_x86 PROPERTIES
 set_property(TARGET Tests_cs_x86 PROPERTY DOTNET_TARGET_FRAMEWORK_VERSION "v4.5")
 
 target_link_libraries(Tests_cs_x86 PUBLIC cs_x86)
-
-# force copy capstone's compiled file to build type's folder
-add_custom_command(TARGET Tests_cs_x86 POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:capstone-shared> $<TARGET_FILE_DIR:Tests_cs_x86>
-)

--- a/cs_x86/CMakeLists.txt
+++ b/cs_x86/CMakeLists.txt
@@ -4,6 +4,11 @@ project(cs_x86 LANGUAGES CSharp)
 # Suppress extra stuff from generated solution
 set(CMAKE_SUPPRESS_REGENERATION true)
 
+# Output all binary files into one folder
+if(NOT DEFINED CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${cs_x86_BINARY_DIR}/bin")
+endif()
+
 include(CSharpUtilities)
 
 file (GLOB_RECURSE SOURCES

--- a/cs_x86/CMakeLists.txt
+++ b/cs_x86/CMakeLists.txt
@@ -12,7 +12,7 @@ file (GLOB_RECURSE SOURCES
 
 csharp_set_windows_forms_properties("Properties/AssemblyInfo.cs")
 
-source_group(TREE ${PROJECT_SOURCE_DIR} FILES ${SOURCES})
+source_group(TREE ${CMAKE_CURRENT_LIST_DIR} FILES ${SOURCES})
 
 add_library(cs_x86 SHARED ${SOURCES})
 


### PR DESCRIPTION
Contains three fixes:
* At least have a solution name for root list.
* Enforce output binary files into one folder instead of separate folders.
  * No longer require workaround fix with custom command call.
* Finally, fixed wrong variable for higher parent list.
  * Couldn't find the source files.

Tested and confirm working with Cxbx-Reloaded's cmake progress.