### PR TITLE
Upgrade API for Capstone

### DIFF
--- a/Tests.cs_x86/CMakeLists.txt
+++ b/Tests.cs_x86/CMakeLists.txt
@@ -11,8 +11,9 @@ endif()
 
 include(CSharpUtilities)
 
-file (GLOB_RECURSE SOURCES
- "*.cs"
+file (GLOB SOURCES
+ "Properties/AssemblyInfo.cs"
+ "Program.cs"
 )
 
 csharp_set_windows_forms_properties("Properties/AssemblyInfo.cs")

--- a/Tests.cs_x86/Program.cs
+++ b/Tests.cs_x86/Program.cs
@@ -20,20 +20,20 @@ namespace Tests.cs_x86
         {
             Console.WriteLine(Capstone.Version());
 
-            //00FBD440 55                   push        ebp  
-            //00FBD441 8B EC                mov         ebp,esp  
-            //00FBD443 6A FF                push        0FFFFFFFFh  
-            //00FBD445 68 9B 2C FC 00       push        0FC2C9Bh  
-            //00FBD44A 64 A1 00 00 00 00    mov         eax,dword ptr fs:[00000000h]  
-            //00FBD450 50                   push        eax  
-            //00FBD451 81 EC B0 02 00 00    sub         esp,2B0h  
-            //00FBD457 53                   push        ebx  
-            //00FBD458 56                   push        esi  
-            //00FBD459 57                   push        edi  
-            //00FBD45A 8D BD 44 FD FF FF    lea         edi,[ebp-2BCh]  
-            //00FBD460 B9 AC 00 00 00       mov         ecx,0ACh  
-            //00FBD465 B8 CC CC CC CC       mov         eax,0CCCCCCCCh  
-            //00FBD46A F3 AB                rep stos    dword ptr es:[edi]  
+            //00FBD440 55                   push        ebp
+            //00FBD441 8b ec                mov         ebp, esp
+            //00FBD443 6a ff                push        -1
+            //00FBD445 68 9b 2c fc 00       push        0xfc2c9b
+            //00FBD44A 64 a1 00 00 00 00    mov         eax, dword ptr fs:[0]
+            //00FBD450 50                   push        eax
+            //00FBD451 81 ec b0 02 00 00    sub         esp, 0x2b0
+            //00FBD457 53                   push        ebx
+            //00FBD458 56                   push        esi
+            //00FBD459 57                   push        edi
+            //00FBD45A 8d bd 44 fd ff ff    lea         edi, [ebp - 0x2bc]
+            //00FBD460 b9 ac 00 00 00       mov         ecx, 0xac
+            //00FBD465 b8 cc cc cc cc       mov         eax, 0xcccccccc
+            //00FBD46A f3 ab                rep stosd   dword ptr es:[edi], eax
 
             byte[] data = new byte[]
             {

--- a/cs_x86/CMakeLists.txt
+++ b/cs_x86/CMakeLists.txt
@@ -11,8 +11,13 @@ endif()
 
 include(CSharpUtilities)
 
-file (GLOB_RECURSE SOURCES
- "*.cs"
+file (GLOB SOURCES
+ "Properties/AssemblyInfo.cs"
+ "Capstone.cs"
+ "CapstoneAPI.cs"
+ "CapstoneStructs.cs"
+ "CapstoneTypes.cs"
+ "CapstoneWrapper.cs"
 )
 
 csharp_set_windows_forms_properties("Properties/AssemblyInfo.cs")

--- a/cs_x86/CapstoneStructs.cs
+++ b/cs_x86/CapstoneStructs.cs
@@ -30,13 +30,13 @@ namespace cs_x86
             address = (ulong)Marshal.ReadInt64(Data, 8);
             size = (ushort)Marshal.ReadInt16(Data, 16);
 
-            bytes = new byte[16];
-            Marshal.Copy(Data + 18, bytes, 0, 16);
+            bytes = new byte[24];
+            Marshal.Copy(Data + 18, bytes, 0, 24);
 
-            Marshal.Copy(Data + 34, buffer, 0, 32);
+            Marshal.Copy(Data + 42, buffer, 0, 32);
             GetStr(out mnemonic, 32);
             
-            Marshal.Copy(Data + 66, buffer, 0, 160);
+            Marshal.Copy(Data + 74, buffer, 0, 160);
             GetStr(out op_str, 160);
         }
     }

--- a/cs_x86/CapstoneTypes.cs
+++ b/cs_x86/CapstoneTypes.cs
@@ -10,6 +10,11 @@
         CS_ARCH_SPARC,      // Sparc architecture
         CS_ARCH_SYSZ,       // SystemZ architecture
         CS_ARCH_XCORE,      // XCore architecture
+        CS_ARCH_M68K,       // 68K architecture
+        CS_ARCH_TMS320C64X, // TMS320C64x architecture
+        CS_ARCH_M680X,      // 680X architecture
+        CS_ARCH_EVM,        // Ethereum architecture
+        CS_ARCH_MOS65XX,    // MOS65XX architecture (including MOS6502)
         CS_ARCH_MAX,
         CS_ARCH_ALL = 0xFFFF, // All architectures - for cs_support()
     };
@@ -27,31 +32,53 @@
         CS_MODE_MICRO = 1 << 4, // MicroMips mode (MIPS)
         CS_MODE_MIPS3 = 1 << 5, // Mips III ISA
         CS_MODE_MIPS32R6 = 1 << 6, // Mips32r6 ISA
-        CS_MODE_MIPSGP64 = 1 << 7, // General Purpose Registers are 64-bit wide (MIPS)
+        CS_MODE_MIPS2 = 1 << 7, // Mips II ISA
         CS_MODE_V9 = 1 << 4, // SparcV9 mode (Sparc)
-        CS_MODE_BIG_ENDIAN = 1 << 31,   // big-endian mode
+        CS_MODE_QPX = 1 << 4, // Quad Processing eXtensions mode (PPC)
+        CS_MODE_M68K_000 = 1 << 1, // M68K 68000 mode
+        CS_MODE_M68K_010 = 1 << 2, // M68K 68010 mode
+        CS_MODE_M68K_020 = 1 << 3, // M68K 68020 mode
+        CS_MODE_M68K_030 = 1 << 4, // M68K 68030 mode
+        CS_MODE_M68K_040 = 1 << 5, // M68K 68040 mode
+        CS_MODE_M68K_060 = 1 << 6, // M68K 68060 mode
+        CS_MODE_BIG_ENDIAN = 1 << 31,  // big-endian mode
         CS_MODE_MIPS32 = CS_MODE_32,    // Mips32 ISA (Mips)
         CS_MODE_MIPS64 = CS_MODE_64,    // Mips64 ISA (Mips)
+        CS_MODE_M680X_6301 = 1 << 1, // M680X Hitachi 6301,6303 mode
+        CS_MODE_M680X_6309 = 1 << 2, // M680X Hitachi 6309 mode
+        CS_MODE_M680X_6800 = 1 << 3, // M680X Motorola 6800,6802 mode
+        CS_MODE_M680X_6801 = 1 << 4, // M680X Motorola 6801,6803 mode
+        CS_MODE_M680X_6805 = 1 << 5, // M680X Motorola/Freescale 6805 mode
+        CS_MODE_M680X_6808 = 1 << 6, // M680X Motorola/Freescale/NXP 68HC08 mode
+        CS_MODE_M680X_6809 = 1 << 7, // M680X Motorola 6809 mode
+        CS_MODE_M680X_6811 = 1 << 8, // M680X Motorola/Freescale/NXP 68HC11 mode
+        CS_MODE_M680X_CPU12 = 1 << 9, // M680X Motorola/Freescale/NXP CPU12
+                                      // used on M68HC12/HCS12
+        CS_MODE_M680X_HCS08 = 1 << 10, // M680X Freescale/NXP HCS08 mode
     };
 
     internal enum cs_opt_type
     {
-        CS_OPT_SYNTAX = 1,  // Assembly output syntax
-        CS_OPT_DETAIL = 2,  // Break down instruction structure into details
-        CS_OPT_MODE = 3,    // Change engine's mode at run-time
-        CS_OPT_MEM = 4, // User-defined dynamic memory related functions
-        CS_OPT_SKIPDATA = 5, // Skip data when disassembling. Then engine is in SKIPDATA mode.
-        CS_OPT_SKIPDATA_SETUP = 6, // Setup user-defined function for SKIPDATA option
+        CS_OPT_INVALID = 0, // No option specified
+        CS_OPT_SYNTAX,  // Assembly output syntax
+        CS_OPT_DETAIL,  // Break down instruction structure into details
+        CS_OPT_MODE,    // Change engine's mode at run-time
+        CS_OPT_MEM, // User-defined dynamic memory related functions
+        CS_OPT_SKIPDATA, // Skip data when disassembling. Then engine is in SKIPDATA mode.
+        CS_OPT_SKIPDATA_SETUP, // Setup user-defined function for SKIPDATA option
+        CS_OPT_MNEMONIC, // Customize instruction mnemonic
+        CS_OPT_UNSIGNED, // print immediate operands in unsigned form
     };
 
     internal enum cs_opt_value
     {
-        CS_OPT_OFF = 0,  // Turn OFF an option - default option of CS_OPT_DETAIL, CS_OPT_SKIPDATA.
+        CS_OPT_OFF = 0,  // Turn OFF an option - default for CS_OPT_DETAIL, CS_OPT_SKIPDATA, CS_OPT_UNSIGNED.
         CS_OPT_ON = 3, // Turn ON an option (CS_OPT_DETAIL, CS_OPT_SKIPDATA).
         CS_OPT_SYNTAX_DEFAULT = 0, // Default asm syntax (CS_OPT_SYNTAX).
-        CS_OPT_SYNTAX_INTEL = 1, // X86 Intel asm syntax - default on X86 (CS_OPT_SYNTAX).
-        CS_OPT_SYNTAX_ATT = 2,   // X86 ATT asm syntax (CS_OPT_SYNTAX).
-        CS_OPT_SYNTAX_NOREGNAME = 3, // Prints register name with only number (CS_OPT_SYNTAX)
+        CS_OPT_SYNTAX_INTEL, // X86 Intel asm syntax - default on X86 (CS_OPT_SYNTAX).
+        CS_OPT_SYNTAX_ATT,   // X86 ATT asm syntax (CS_OPT_SYNTAX).
+        CS_OPT_SYNTAX_NOREGNAME, // Prints register name with only number (CS_OPT_SYNTAX)
+        CS_OPT_SYNTAX_MASM, // X86 Intel Masm syntax (CS_OPT_SYNTAX).
     };
 
     internal enum cs_op_type
@@ -63,6 +90,13 @@
         CS_OP_FP,           // Floating-Point operand.
     };
 
+    internal enum cs_ac_type
+    {
+        CS_AC_INVALID = 0,        // Uninitialized/invalid access type.
+        CS_AC_READ = 1 << 0,   // Operand read from memory or register.
+        CS_AC_WRITE = 1 << 1,   // Operand write to memory or register.
+    };
+
     internal enum cs_group_type
     {
         CS_GRP_INVALID = 0,  // uninitialized/invalid group.
@@ -71,6 +105,8 @@
         CS_GRP_RET,     // all return instructions
         CS_GRP_INT,     // all interrupt instructions (int+syscall)
         CS_GRP_IRET,    // all interrupt return instructions
+        CS_GRP_PRIVILEGE,    // all privileged instructions
+        CS_GRP_BRANCH_RELATIVE, // all relative branching instructions
     };
 
     internal enum cs_err
@@ -89,5 +125,6 @@
         CS_ERR_SKIPDATA, // Access irrelevant data for "data" instruction in SKIPDATA mode
         CS_ERR_X86_ATT,  // X86 AT&T syntax is unsupported (opt-out at compile time)
         CS_ERR_X86_INTEL, // X86 Intel syntax is unsupported (opt-out at compile time)
+        CS_ERR_X86_MASM, // X86 Masm syntax is unsupported (opt-out at compile time)
     };
 }


### PR DESCRIPTION
Also fixes a headache where cmake would include the autogenerated `obj/[Debug/Release]/.NETFramework,Version=v4.5.AssemblyAttributes.cs` because GLOB_RECURSE was set to include everything