### PR TITLE
Fix CMake 3.12 Install And Make Configurable DOTNET define

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,3 @@ add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/third_party/capstone")
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/cs_x86")
 
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/Tests.cs_x86")
-
-# copy binary files to install path
-# copy capstone module binary without other misc files
-install(PROGRAMS $<TARGET_FILE_DIR:cs_x86>/${CMAKE_SHARED_LIBRARY_PREFIX}capstone${CMAKE_SHARED_LIBRARY_SUFFIX} DESTINATION bin)
-install(TARGETS cs_x86 RUNTIME DESTINATION bin)

--- a/cs_x86/CMakeLists.txt
+++ b/cs_x86/CMakeLists.txt
@@ -26,12 +26,17 @@ source_group(TREE ${CMAKE_CURRENT_LIST_DIR} FILES ${SOURCES})
 
 add_library(cs_x86 SHARED ${SOURCES})
 
+if (NOT DOTNET_TARGET_FRAMEWORK_VERSION)
+ set(DOTNET_TARGET_FRAMEWORK_VERSION "v4.5")
+endif()
+
 set_target_properties(cs_x86 PROPERTIES 
  VS_DOTNET_REFERENCES
  "Microsoft.CSharp;System;System.Core;System.Xml;System.Xml.Linq;System.Data"
+
+ DOTNET_TARGET_FRAMEWORK_VERSION ${DOTNET_TARGET_FRAMEWORK_VERSION}
 )
 
-set_property(TARGET cs_x86 PROPERTY DOTNET_TARGET_FRAMEWORK_VERSION "v4.5")
 
 target_link_libraries(cs_x86 PUBLIC capstone-shared)
 

--- a/cs_x86/CMakeLists.txt
+++ b/cs_x86/CMakeLists.txt
@@ -34,3 +34,8 @@ set_target_properties(cs_x86 PROPERTIES
 set_property(TARGET cs_x86 PROPERTY DOTNET_TARGET_FRAMEWORK_VERSION "v4.5")
 
 target_link_libraries(cs_x86 PUBLIC capstone-shared)
+
+# copy cs_x86 binary file to install path
+install(TARGETS cs_x86 RUNTIME DESTINATION bin)
+# copy capstone module binary without other misc files
+install(PROGRAMS $<TARGET_FILE_DIR:cs_x86>/${CMAKE_SHARED_LIBRARY_PREFIX}capstone${CMAKE_SHARED_LIBRARY_SUFFIX} DESTINATION bin)


### PR DESCRIPTION
For CMake 3.12 and below, there's an issue with attempt to generate solution files.

Then I added another commit to make `DOTNET_TARGET_FRAMEWORK_VERSION` configurable in order for parent projects able to change .NET Framework version as Visual Studio 2022 has drop support for v4.5 framework.